### PR TITLE
Remove progress bars from the convert module

### DIFF
--- a/pdfconduit/convert/flatten.py
+++ b/pdfconduit/convert/flatten.py
@@ -9,9 +9,7 @@ from pdfconduit.utils.path import add_suffix
 
 
 class Flatten:
-    def __init__(
-        self, file_name, scale=1.0, suffix="flat", tempdir=None, progress_bar=None
-    ):
+    def __init__(self, file_name, scale=1.0, suffix="flat", tempdir=None):
         """Create a flat single-layer PDF by converting each page to a PNG image"""
         self._file_name = file_name
 
@@ -26,7 +24,6 @@ class Flatten:
 
         self.suffix = suffix
         self.directory = os.path.dirname(file_name)
-        self.progress_bar = progress_bar
 
         if scale and scale != 0 and scale != 1.0:
             self.file_name = upscale(file_name, scale=scale, tempdir=self.tempdir)
@@ -40,18 +37,14 @@ class Flatten:
         return str(self.pdf)
 
     def get_imgs(self):
-        self.imgs = PDF2IMG(
-            self.file_name, tempdir=self.tempdir, progress_bar=self.progress_bar
-        ).save()
+        self.imgs = PDF2IMG(self.file_name, tempdir=self.tempdir).save()
         return self.imgs
 
     def save(self, remove_temps=True):
         if self.imgs is None:
             self.get_imgs()
-        i2p = IMG2PDF(self.imgs, self.directory, self.tempdir, self.progress_bar)
-        self.pdf = i2p.save(
-            clean_temp=False, output_name=add_suffix(self._file_name, self.suffix)
-        )
+        i2p = IMG2PDF(self.imgs, self.directory, self.tempdir)
+        self.pdf = i2p.save(clean_temp=False, output_name=add_suffix(self._file_name, self.suffix))
         self.cleanup(remove_temps)
         return self.pdf
 

--- a/pdfconduit/convert/flatten.py
+++ b/pdfconduit/convert/flatten.py
@@ -44,7 +44,9 @@ class Flatten:
         if self.imgs is None:
             self.get_imgs()
         i2p = IMG2PDF(self.imgs, self.directory, self.tempdir)
-        self.pdf = i2p.save(clean_temp=False, output_name=add_suffix(self._file_name, self.suffix))
+        self.pdf = i2p.save(
+            clean_temp=False, output_name=add_suffix(self._file_name, self.suffix)
+        )
         self.cleanup(remove_temps)
         return self.pdf
 

--- a/pdfconduit/convert/img2pdf.py
+++ b/pdfconduit/convert/img2pdf.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from PIL import Image
-from tqdm import tqdm
 
 from pdfconduit.modify.canvas import CanvasImg, CanvasObjects
 from pdfconduit.modify.draw import WatermarkDraw
@@ -11,7 +10,7 @@ from pdfconduit.transform.merge import Merge
 
 
 class IMG2PDF:
-    def __init__(self, imgs=None, destination=None, tempdir=None, progress_bar=None):
+    def __init__(self, imgs=None, destination=None, tempdir=None):
         """Convert each image into a PDF page and merge all pages to one PDF file"""
         self.imgs = imgs
         self.output_dir = destination
@@ -23,7 +22,6 @@ class IMG2PDF:
             self.tempdir = self._temp.name
         else:
             self.tempdir = tempdir
-        self.progress_bar = progress_bar
 
         self._pdf_pages = None
 
@@ -39,15 +37,7 @@ class IMG2PDF:
 
     def _image_loop(self):
         """Retrieve an iterable of images either with, or without a progress bar."""
-        if self.progress_bar and "tqdm" in self.progress_bar.lower():
-            return tqdm(
-                self.imgs,
-                desc="Saving PNGs as flat PDFs",
-                total=len(self.imgs),
-                unit="PDFs",
-            )
-        else:
-            return self.imgs
+        return self.imgs
 
     def _convert(self, image, output=None):
         """Private method for converting a single PNG image to a PDF."""
@@ -85,7 +75,5 @@ class IMG2PDF:
         return m
 
 
-def img2pdf(
-    imgs, output_name="merged_imgs", destination=None, tempdir=None, progress_bar=None
-):
-    return IMG2PDF(imgs, destination, tempdir, progress_bar).save(output_name)
+def img2pdf(imgs, output_name="merged_imgs", destination=None, tempdir=None):
+    return IMG2PDF(imgs, destination, tempdir).save(output_name)

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -5,27 +5,17 @@ from tempfile import NamedTemporaryFile
 
 import fitz
 from PIL import Image
-from tqdm import tqdm
 
 from pdfconduit.utils.path import add_suffix
 
 
 class PDF2IMG:
-    def __init__(
-        self,
-        file_name,
-        output=None,
-        tempdir=None,
-        ext=".png",
-        progress_bar=None,
-        alpha=False,
-    ):
+    def __init__(self, file_name, output=None, tempdir=None, ext=".png", alpha=False):
         """Convert each page of a PDF file into a PNG image"""
         self.file_name = file_name
         self.output = output
         self.tempdir = tempdir
         self.ext = ext
-        self.progress_bar = progress_bar
         self.alpha = alpha
 
         self.doc = fitz.open(self.file_name)
@@ -42,20 +32,7 @@ class PDF2IMG:
         return self._page_data
 
     def _get_pdf_data(self):
-        # TQDM progress bar
-        if self.progress_bar == "tqdm":
-            return [
-                self._get_page_data(cur_page)
-                for cur_page in tqdm(
-                    range(len(self.doc)),
-                    desc="Getting PDF page data",
-                    total=len(self.doc),
-                    unit="Pages",
-                )
-            ]
-        # No progress bar
-        else:
-            return [self._get_page_data(cur_page) for cur_page in range(len(self.doc))]
+        return [self._get_page_data(cur_page) for cur_page in range(len(self.doc))]
 
     def _get_page_data(self, pno, zoom=0):
         """
@@ -100,22 +77,8 @@ class PDF2IMG:
                 return temp.name
 
     def save(self):
-        # TQDM progress bar
-        if self.progress_bar == "tqdm":
-            loop = enumerate(
-                tqdm(
-                    self.pdf_data,
-                    desc="Saving PDF pages as PNGs",
-                    total=len(self.pdf_data),
-                    unit="PNGs",
-                )
-            )
-        # No progress bar
-        else:
-            loop = enumerate(self.pdf_data)
-
         saved = []
-        for i, img in loop:
+        for i, img in enumerate(self.pdf_data):
             output = self._get_output(i)
             saved.append(output)
             with Image.open(BytesIO(img)) as image:
@@ -124,15 +87,12 @@ class PDF2IMG:
         return saved
 
 
-def pdf2img(
-    file_name, output=None, tempdir=None, ext="png", progress_bar=None, alpha=False
-):
+def pdf2img(file_name, output=None, tempdir=None, ext="png", alpha=False):
     """Wrapper function for PDF2IMG class"""
     return PDF2IMG(
         file_name=file_name,
         output=output,
         tempdir=tempdir,
         ext=ext,
-        progress_bar=progress_bar,
         alpha=alpha,
     ).save()


### PR DESCRIPTION
- remove use of progress bars from flatten.py, img2pdf.py & pdf2img.py
- no use of PyPDF3 found in module so no porting to pypdf is required