### PR TITLE
Port 'utils' module to use pypdf back-end

### DIFF
--- a/pdfconduit/utils/info.py
+++ b/pdfconduit/utils/info.py
@@ -13,7 +13,7 @@ class Info:
             self.pdf = self._pypdf3_reader(path, password)
 
     @staticmethod
-    def _pypdf3_reader(path, password):
+    def _pypdf3_reader(path, password) -> PdfFileReader:
         """Read PDF and decrypt if encrypted."""
         pdf = PdfFileReader(path) if not isinstance(path, PdfFileReader) else path
         if password:
@@ -21,8 +21,10 @@ class Info:
         return pdf
 
     @staticmethod
-    def _resolved_objects(pdf, xobject):
-        """Retrieve rotatation info."""
+    def _resolved_objects(pdf, xobject, use_pypdf=False):
+        """Retrieve rotation info."""
+        if use_pypdf:
+            return [pdf.get_page(i).get(xobject) for i in range(pdf.get_num_pages())][0]
         return [pdf.getPage(i).get(xobject) for i in range(pdf.getNumPages())][0]
 
     @property
@@ -40,6 +42,8 @@ class Info:
     @property
     def pages(self):
         """Retrieve PDF number of pages"""
+        if self.use_pypdf:
+            return self.pdf.get_num_pages()
         return self.pdf.getNumPages()
 
     @property
@@ -52,6 +56,8 @@ class Info:
     def resources(self):
         """Retrieve contents of each page of PDF"""
         # todo: refactor to generator?
+        if self.use_pypdf:
+            return [self.pdf.get_page(i) for i in range(self.pdf.get_num_pages())]
         return [self.pdf.getPage(i) for i in range(self.pdf.getNumPages())]
 
     @property
@@ -68,13 +74,20 @@ class Info:
         """Get width and height of a PDF"""
         # todo: add page parameter?
         # todo: add height & width methods?
-        size = self.pdf.getPage(0).mediaBox
+        if self.use_pypdf:
+            size = self.pdf.get_page(0).mediabox
+        else:
+            size = self.pdf.getPage(0).mediaBox
         return {"w": float(size[2]), "h": float(size[3])}
 
     @property
     def size(self):
         """Get width and height of a PDF"""
-        size = self.pdf.getPage(0).mediaBox
+        if self.use_pypdf:
+            size = self.pdf.get_page(0).mediabox
+        else:
+            size = self.pdf.getPage(0).mediaBox
+
         return float(size[2]), float(size[3])
 
     @property
@@ -83,7 +96,7 @@ class Info:
         # todo: add page param
         # todo: refactor to `rotation()`
         # todo: add is_rotated
-        return self._resolved_objects(self.pdf, "/Rotate")
+        return self._resolved_objects(self.pdf, "/Rotate", self.use_pypdf)
 
     @property
     def permissions(self):

--- a/pdfconduit/utils/info.py
+++ b/pdfconduit/utils/info.py
@@ -1,7 +1,8 @@
 # Retrieve information about a PDF document
 from PyPDF3 import PdfFileReader
-from pdfconduit.utils.read import pypdf_reader
+
 from pdfconduit.utils._permissions import Permissions
+from pdfconduit.utils.read import pypdf_reader
 
 
 class Info:

--- a/pdfconduit/utils/read.py
+++ b/pdfconduit/utils/read.py
@@ -2,7 +2,7 @@ from PyPDF3 import PdfFileReader
 from pypdf import PdfReader
 
 
-def pypdf3_reader(pdf, decrypt=None):
+def pypdf3_reader(pdf, decrypt=None) -> PdfFileReader:
     """
     Retrieve a PdfFileReader object that has been decrypted if a password is specified.
 
@@ -18,7 +18,7 @@ def pypdf3_reader(pdf, decrypt=None):
         return PdfFileReader(pdf)
 
 
-def pypdf_reader(pdf, decrypt=None):
+def pypdf_reader(pdf, decrypt=None) -> PdfReader:
     """
     Retrieve a PdfFileReader object that has been decrypted if a password is specified.
 

--- a/pdfconduit/utils/write.py
+++ b/pdfconduit/utils/write.py
@@ -1,45 +1,80 @@
 # Write two (2) PDFs to a destination file
-from PyPDF3 import PdfFileWriter, PdfFileReader
+from PyPDF3 import (
+    PdfFileReader as Pypdf3Reader,
+    PdfFileWriter as Pypdf3Writer,
+)
+from pypdf import PdfReader as PypdfReader, PdfWriter as PypdfWriter
 
 
-def overlay_pdfs(top_pdf, bottom_pdf, destination):
+def overlay_pdfs(top_pdf, bottom_pdf, destination, use_pypdf=False):
     # todo: possibly remove?
     """
     Overlay PDF objects to files
     :param top_pdf: PDF object to be placed on top
     :param bottom_pdf: PDF file to be placed underneath
     :param destination: Desintation path
+    :param use_pypdf:
     """
-    drawing = PdfFileReader(top_pdf)  # Create new PDF object
-    template = PdfFileReader(bottom_pdf)  # read your existing PDF
+    if use_pypdf:
+        drawing = PypdfReader(top_pdf)  # Create new PDF object
+        template = PypdfReader(bottom_pdf)  # read your existing PDF
 
-    # add the "watermark" (which is the new pdf) on the existing page
-    page = template.getPage(0)
-    page.mergePage(drawing.getPage(0))
-    output = PdfFileWriter()  # Create new PDF file
-    output.addPage(page)
+        # add the "watermark" (which is the new pdf) on the existing page
+        page = template.get_page(0)
+        page.merge_page(drawing.get_page(0))
+        output = PypdfWriter()  # Create new PDF file
+        output.add_page(page)
 
-    # finally, write "output" to a real file
-    with open(destination, "wb") as outputStream:
-        output.write(outputStream)
+        # finally, write "output" to a real file
+        with open(destination, "wb") as outputStream:
+            output.write(outputStream)
+    else:
+        drawing = Pypdf3Reader(top_pdf)  # Create new PDF object
+        template = Pypdf3Reader(bottom_pdf)  # read your existing PDF
+
+        # add the "watermark" (which is the new pdf) on the existing page
+        page = template.getPage(0)
+        page.mergePage(drawing.getPage(0))
+        output = Pypdf3Writer()  # Create new PDF file
+        output.addPage(page)
+
+        # finally, write "output" to a real file
+        with open(destination, "wb") as outputStream:
+            output.write(outputStream)
 
 
-def write_pdf(pdf_obj, destination):
+def write_pdf(pdf_obj, destination, use_pypdf=False):
     """
     Write PDF object to file
     :param pdf_obj: PDF object to be written to file
-    :param destination: Desintation path
+    :param destination: Destination path
+    :param use_pypdf:
     """
-    reader = PdfFileReader(pdf_obj)  # Create new PDF object
-    writer = PdfFileWriter()
+    if use_pypdf:
+        reader = PypdfReader(pdf_obj)  # Create new PDF object
+        writer = PypdfWriter()
 
-    page_count = reader.getNumPages()
+        page_count = reader.get_num_pages()
 
-    # add the "watermark" (which is the new pdf) on the existing page
-    for page_number in range(page_count):
-        page = reader.getPage(page_number)
-        writer.addPage(page)
+        # add the "watermark" (which is the new pdf) on the existing page
+        for page_number in range(page_count):
+            page = reader.get_page(page_number)
+            writer.add_page(page)
 
-    # finally, write "output" to a real file
-    with open(destination, "wb") as outputStream:
-        writer.write(outputStream)
+        # finally, write "output" to a real file
+        with open(destination, "wb") as outputStream:
+            writer.write(outputStream)
+    else:
+        reader = Pypdf3Reader(pdf_obj)  # Create new PDF object
+        writer = Pypdf3Writer()
+
+        page_count = reader.getNumPages()
+
+        # add the "watermark" (which is the new pdf) on the existing page
+        for page_number in range(page_count):
+            page = reader.getPage(page_number)
+            writer.addPage(page)
+
+        # finally, write "output" to a real file
+        with open(destination, "wb") as outputStream:
+            writer.write(outputStream)

--- a/tests/test_utils_info.py
+++ b/tests/test_utils_info.py
@@ -6,7 +6,7 @@ from pdfconduit import Info
 from tests import *
 
 
-class TestInfo(unittest.TestCase):
+class TestInfoPypdf3(unittest.TestCase):
     @Timer.decorator
     def test_pypdf3_is_encrypted(self):
         info = self._get_info("encrypted.pdf")
@@ -145,6 +145,153 @@ class TestInfo(unittest.TestCase):
     @staticmethod
     def _get_info(filename, password=None):
         return Info(test_data_path(filename), password=password)
+
+
+class TestInfoPypdf(unittest.TestCase):
+    @Timer.decorator
+    def test_pypdf3_is_encrypted(self):
+        info = self._get_info("encrypted.pdf")
+
+        self.assertTrue(info.encrypted)
+
+    @Timer.decorator
+    def test_pypdf3_is_decrypted(self):
+        info = self._get_info("article.pdf")
+
+        self.assertTrue(info.decrypted)
+
+    @Timer.decorator
+    def test_pypdf3_is_not_encrypted(self):
+        info = self._get_info("article.pdf")
+
+        self.assertFalse(info.encrypted)
+
+    @Timer.decorator
+    def test_pypdf3_is_not_decrypted(self):
+        info = self._get_info("encrypted.pdf")
+
+        self.assertFalse(info.decrypted)
+
+    @Timer.decorator
+    def test_pypdf3_pages(self):
+        info = self._get_info("article.pdf")
+
+        self.assertIsInstance(info.pages, int)
+        self.assertEqual(info.pages, 1)
+        self.assertEqual(Info(test_data_path("document.pdf")).pages, 11)
+
+    @Timer.decorator
+    def test_pypdf3_metadata(self):
+        info = self._get_info("article.pdf")
+
+        self.assertIsInstance(info.metadata, dict)
+        self.assertEqual(
+            info.metadata["/Creator"], "This PDF is created by PDF4U Pro 2.0"
+        )
+        self.assertEqual(
+            info.metadata["/CreationDate"],
+            "D:20040120105826",
+        )
+        self.assertEqual(
+            info.metadata["/Producer"],
+            "PDF4U Adobe PDF Creator 2.0",
+        )
+
+    @Timer.decorator
+    def test_pypdf3_resources(self):
+        info = self._get_info("article.pdf")
+
+        self.assertEqual(info.pages, len(info.resources()))
+
+        resources = info.resources()[0]
+        self.assertIsInstance(resources, dict)
+        self.assertEqual(resources["/Type"], "/Page")
+
+        mediabox = list(resources["/MediaBox"])
+        self.assertEqual(mediabox[0], 0)
+        self.assertEqual(mediabox[1], 0)
+        self.assertEqual(float(mediabox[2]), 595.276)
+        self.assertEqual(float(mediabox[3]), 841.89)
+
+    @Timer.decorator
+    def test_pypdf3_security_encrypted_pdf(self):
+        info = self._get_info("encrypted.pdf")
+
+        self.assertIsInstance(info.security, dict)
+        self.assertTrue("/V" in info.security)
+        self.assertTrue("/R" in info.security)
+        self.assertTrue("/Length" in info.security)
+        self.assertTrue("/P" in info.security)
+        self.assertTrue("/Filter" in info.security)
+        self.assertTrue("/O" in info.security)
+        self.assertTrue("/U" in info.security)
+
+    @Timer.decorator
+    def test_pypdf3_security_decrypted_pdf(self):
+        info = self._get_info("encrypted.pdf", "foo")
+
+        self.assertIsInstance(info.security, dict)
+        self.assertTrue("/V" in info.security)
+        self.assertTrue("/R" in info.security)
+        self.assertTrue("/Length" in info.security)
+        self.assertTrue("/P" in info.security)
+        self.assertTrue("/Filter" in info.security)
+        self.assertTrue("/O" in info.security)
+        self.assertTrue("/U" in info.security)
+
+    @Timer.decorator
+    def test_pypdf3_security_passwordless_pdf(self):
+        info = self._get_info("article.pdf")
+
+        self.assertIsInstance(info.security, dict)
+        self.assertEqual(info.security, {})
+
+    @Timer.decorator
+    def test_pypdf3_dimensions(self):
+        info = self._get_info("article.pdf")
+
+        self.assertIsInstance(info.dimensions, dict)
+        self.assertTrue("w" in info.dimensions)
+        self.assertTrue("h" in info.dimensions)
+        self.assertIsInstance(info.dimensions["w"], float)
+        self.assertIsInstance(info.dimensions["h"], float)
+        self.assertEqual(info.dimensions["w"], 595.276)
+        self.assertEqual(info.dimensions["h"], 841.89)
+
+    @Timer.decorator
+    def test_pypdf3_size(self):
+        info = self._get_info("article.pdf")
+
+        self.assertIsInstance(info.size, tuple)
+        self.assertEqual(len(info.size), 2)
+        self.assertIsInstance(info.size[0], float)
+        self.assertIsInstance(info.size[1], float)
+        self.assertEqual(info.size[0], 595.276)
+        self.assertEqual(info.size[1], 841.89)
+
+    @Timer.decorator
+    def test_pypdf3_size_and_dimensions_are_equal(self):
+        info = self._get_info("article.pdf")
+
+        self.assertEqual(info.size[0], info.dimensions["w"])
+        self.assertEqual(info.size[1], info.dimensions["h"])
+
+    @Timer.decorator
+    def test_pypdf3_rotate_no_rotation(self):
+        info = self._get_info("article.pdf")
+
+        self.assertEqual(info.rotate, None)
+
+    @Timer.decorator
+    def test_pypdf3_rotate_rotated(self):
+        info = self._get_info("rotated.pdf")
+
+        self.assertIsInstance(info.rotate, int)
+        self.assertEqual(info.rotate, 90)
+
+    @staticmethod
+    def _get_info(filename, password=None):
+        return Info(test_data_path(filename), password=password, use_pypdf=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- port utils to use pypdf back-end instead of just pypdf3
- add return type hinting to pdf reader functions