### PR TITLE
Refactor classes that use multiple PDF driver methods (e.g. pdfrw or pypdf)

### DIFF
--- a/pdfconduit/conduit/watermark/add.py
+++ b/pdfconduit/conduit/watermark/add.py
@@ -89,6 +89,7 @@ class WatermarkAdd:
         # 2c. Upscale PDF if it is smaller than a letter
         if pdf_file["w"] <= letter_size["w"] or pdf_file["h"] <= letter_size["h"]:
             scale = float(letter_size["w"] / pdf_file["w"])
+            # todo: add use of upscale class instead of function
             pdf_file["upscaled"] = upscale(
                 pdf_file["path"], scale=scale, tempdir=self.tempdir
             )

--- a/pdfconduit/conduit/watermark/add.py
+++ b/pdfconduit/conduit/watermark/add.py
@@ -55,7 +55,7 @@ class WatermarkAdd:
         self.document_reader = pypdf_reader(document, decrypt)
         self.document = self._get_document_info(document)
         self.watermark_file = self._get_watermark_info(self.document, watermark)
-        pdf_fname, wtrmrk_fname = self._set_filenames
+        self.pdf_fname, self.wtrmrk_fname = self._set_filenames
 
         if overwrite:
             self.output_filename = document
@@ -66,8 +66,6 @@ class WatermarkAdd:
         else:
             tmpf = NamedTemporaryFile(suffix=".pdf", dir=self.tempdir, delete=False)
             self.output_filename = resource_path(tmpf.name)
-
-        self.add(pdf_fname, wtrmrk_fname)
 
     def __str__(self):
         return str(self.output_filename)
@@ -154,8 +152,11 @@ class WatermarkAdd:
             watermark = self.watermark_file["path"]
         return pdf, watermark
 
-    def add(self, document: str, watermark: str) -> str:
+    def add(self) -> str:
         """Add watermark to PDF by merging original PDF and watermark file."""
+        document = self.pdf_fname
+        watermark = self.wtrmrk_fname
+
         # 5a. Create output PDF file name
         output_filename = self.output_filename
 
@@ -245,6 +246,7 @@ class WatermarkAdd:
 
             # Write out the destination file
             PdfWriter(output_filename, trailer=trailer).write()
+            return output_filename
 
         if self.method.startswith("pypdf"):
             return pypdf()

--- a/pdfconduit/conduit/watermark/watermark.py
+++ b/pdfconduit/conduit/watermark/watermark.py
@@ -202,8 +202,7 @@ class Watermark:
             watermark = self.watermark
         if not document:
             document = self.document
-        self.document = str(
-            WatermarkAdd(
+        self.document = WatermarkAdd(
                 document,
                 watermark,
                 output=output,
@@ -211,8 +210,7 @@ class Watermark:
                 tempdir=self.tempdir,
                 suffix=suffix,
                 method=method,
-            )
-        )
+            ).add()
         if self.use_receipt:
             self.receipt.add("Watermarked PDF", os.path.basename(self.document))
         if self.open_file:

--- a/pdfconduit/conduit/watermark/watermark.py
+++ b/pdfconduit/conduit/watermark/watermark.py
@@ -172,7 +172,7 @@ class Watermark:
         watermark: Optional[str] = None,
         underneath: bool = False,
         output: Optional[str] = None,
-        suffix: str = "watermarked",
+        suffix: Optional[str] = "watermarked",
         method: str = "pdfrw",
     ) -> str:
         """
@@ -202,15 +202,21 @@ class Watermark:
             watermark = self.watermark
         if not document:
             document = self.document
-        self.document = WatermarkAdd(
+
+        watermarker = WatermarkAdd(
                 document,
                 watermark,
                 output=output,
                 underneath=underneath,
                 tempdir=self.tempdir,
                 suffix=suffix,
-                method=method,
-            ).add()
+            )
+        if method == 'pdfrw':
+            watermarker.use_pdfrw()
+        else:
+            watermarker.use_pypdf()
+        self.document = watermarker.add()
+
         if self.use_receipt:
             self.receipt.add("Watermarked PDF", os.path.basename(self.document))
         if self.open_file:

--- a/pdfconduit/conduit/watermark/watermark.py
+++ b/pdfconduit/conduit/watermark/watermark.py
@@ -204,14 +204,14 @@ class Watermark:
             document = self.document
 
         watermarker = WatermarkAdd(
-                document,
-                watermark,
-                output=output,
-                underneath=underneath,
-                tempdir=self.tempdir,
-                suffix=suffix,
-            )
-        if method == 'pdfrw':
+            document,
+            watermark,
+            output=output,
+            underneath=underneath,
+            tempdir=self.tempdir,
+            suffix=suffix,
+        )
+        if method == "pdfrw":
             watermarker.use_pdfrw()
         else:
             watermarker.use_pypdf()

--- a/pdfconduit/conduit/watermark/watermark.py
+++ b/pdfconduit/conduit/watermark/watermark.py
@@ -243,6 +243,7 @@ class Watermark:
             Restrict permissions to print only
         :param allow_commenting:
         :param user_pw: str
+        :param document:
         :return: str
             Encrypted PDF full path
         """

--- a/pdfconduit/convert/img2pdf.py
+++ b/pdfconduit/convert/img2pdf.py
@@ -74,11 +74,9 @@ class IMG2PDF:
         return [self._convert(image) for image in self._image_loop()]
 
     def save(self, output_name: str = "merged imgs", clean_temp: bool = True) -> str:
-        m = str(
-            Merge(self.pdf_pages, output_name=output_name, output_dir=self.output_dir)
-        )
+        m = Merge(self.pdf_pages, output_name=output_name, output_dir=self.output_dir)
         self.cleanup(clean_temp)
-        return m
+        return m.merge()
 
 
 def img2pdf(

--- a/pdfconduit/modify/canvas/objects.py
+++ b/pdfconduit/modify/canvas/objects.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pdfconduit.modify import LETTER
 
 
@@ -38,7 +40,7 @@ class CanvasImg:
         y: float = 0,
         w: int = LETTER[0],
         h: int = LETTER[1],
-        mask: str = "auto",
+        mask: Optional[str] = "auto",
         preserve_aspect_ratio: bool = True,
         centered: bool = False,
     ):

--- a/pdfconduit/transform/merge.py
+++ b/pdfconduit/transform/merge.py
@@ -14,6 +14,8 @@ INPUT_PDFS_TYPE = Union[list, str]
 
 
 class Merge:
+    file: str = None
+
     def __init__(
         self,
         input_pdfs: INPUT_PDFS_TYPE,
@@ -27,7 +29,6 @@ class Merge:
             self.directory, output_name.replace(".pdf", "") + ".pdf"
         )
         self.method = method
-        self.file = self.merge(self.pdfs, self.output)
 
     def __str__(self) -> str:
         return str(self.file)
@@ -57,12 +58,14 @@ class Merge:
             ]
         # todo: raise error if conditions aren't met?
 
-    def merge(self, pdf_files: INPUT_PDFS_TYPE, output: str) -> str:
+    def merge(self) -> str:
         """Merge list of PDF files to a single PDF file."""
         if self.method.startswith("pypdf"):
-            return self.pypdf(pdf_files, output)
+            self.file = self.pypdf(self.pdfs, self.output)
         else:
-            return self.pdfrw(pdf_files, output)
+            self.file = self.pdfrw(self.pdfs, self.output)
+
+        return self.file
 
     @staticmethod
     def pdfrw(pdf_files: INPUT_PDFS_TYPE, output: str):

--- a/pdfconduit/transform/rotate.py
+++ b/pdfconduit/transform/rotate.py
@@ -36,13 +36,16 @@ class Rotate:
         else:
             self.outfn = NamedTemporaryFile(suffix=".pdf").name
 
-        if method.startswith("pypdf"):
-            self.pypdf()
-        else:
-            self.pdfrw()
+        self.method = method
 
     def __str__(self) -> str:
         return self.file
+
+    def rotate(self) -> str:
+        if self.method.startswith("pypdf"):
+            return self.pypdf()
+        else:
+            return self.pdfrw()
 
     @property
     def file(self) -> str:
@@ -87,4 +90,4 @@ def rotate(
     method: str = "pdfrw",
 ):
     """Rotate PDF by increments of 90 degrees."""
-    return str(Rotate(file_name, rotation, suffix, tempdir, method))
+    return Rotate(file_name, rotation, suffix, tempdir, method).rotate()

--- a/pdfconduit/transform/rotate.py
+++ b/pdfconduit/transform/rotate.py
@@ -9,17 +9,18 @@ from pdfrw import (
 )
 from pypdf import PdfReader as PypdfReader, PdfWriter as PypdfWriter
 
+from pdfconduit.utils.driver import PdfDriver
 from pdfconduit.utils.path import add_suffix
 
 
-class Rotate:
+class Rotate(PdfDriver):
+
     def __init__(
         self,
         file_name: str,
         rotation: int,
         suffix: str = "rotated",
         tempdir: Optional[str] = None,
-        method: str = "pdfrw",
     ):
         self.file_name = file_name
         self.rotation = rotation
@@ -36,16 +37,11 @@ class Rotate:
         else:
             self.outfn = NamedTemporaryFile(suffix=".pdf").name
 
-        self.method = method
-
     def __str__(self) -> str:
         return self.file
 
     def rotate(self) -> str:
-        if self.method.startswith("pypdf"):
-            return self.pypdf()
-        else:
-            return self.pdfrw()
+        return self.execute()
 
     @property
     def file(self) -> str:
@@ -90,4 +86,10 @@ def rotate(
     method: str = "pdfrw",
 ):
     """Rotate PDF by increments of 90 degrees."""
-    return Rotate(file_name, rotation, suffix, tempdir, method).rotate()
+    # todo: remove use of function or clean this up
+    rotater = Rotate(file_name, rotation, suffix, tempdir)
+    if method == 'pdfrw':
+        rotater.use_pdfrw()
+    else:
+        rotater.use_pypdf()
+    return rotater.rotate()

--- a/pdfconduit/transform/rotate.py
+++ b/pdfconduit/transform/rotate.py
@@ -88,7 +88,7 @@ def rotate(
     """Rotate PDF by increments of 90 degrees."""
     # todo: remove use of function or clean this up
     rotater = Rotate(file_name, rotation, suffix, tempdir)
-    if method == 'pdfrw':
+    if method == "pdfrw":
         rotater.use_pdfrw()
     else:
         rotater.use_pypdf()

--- a/pdfconduit/transform/upscale.py
+++ b/pdfconduit/transform/upscale.py
@@ -53,14 +53,17 @@ class Upscale:
         self.target_w = dims["w"] * self.scale
         self.target_h = dims["h"] * self.scale
 
-        # Execute either pdfrw or PyPDF3 method
-        if method.startswith("pypdf"):
-            self.pypdf()
-        else:
-            self.pdfrw()
+        self.method = method
 
     def __str__(self) -> str:
         return self.file
+
+    def upscale(self) -> str:
+        # Execute either pdfrw or PyPDF3 method
+        if self.method.startswith("pypdf"):
+            return self.pypdf()
+        else:
+            return self.pdfrw()
 
     @property
     def file(self) -> str:
@@ -115,4 +118,4 @@ def upscale(
     tempdir: Optional[str] = None,
     method: str = "pdfrw",
 ):
-    return str(Upscale(file_name, margin_x, margin_y, scale, suffix, tempdir, method))
+    return Upscale(file_name, margin_x, margin_y, scale, suffix, tempdir, method).upscale()

--- a/pdfconduit/transform/upscale.py
+++ b/pdfconduit/transform/upscale.py
@@ -114,7 +114,7 @@ def upscale(
     method: str = "pdfrw",
 ):
     upscaler = Upscale(file_name, margin_x, margin_y, scale, suffix, tempdir)
-    if method == 'pdfrw':
+    if method == "pdfrw":
         upscaler.use_pdfrw()
     else:
         upscaler.use_pypdf()

--- a/pdfconduit/transform/upscale.py
+++ b/pdfconduit/transform/upscale.py
@@ -14,11 +14,12 @@ from pypdf import (
     PdfWriter as pypdfWriter,
 )
 
+from pdfconduit.utils.driver import PdfDriver
 from pdfconduit.utils.info import Info
 from pdfconduit.utils.path import add_suffix
 
 
-class Upscale:
+class Upscale(PdfDriver):
     def __init__(
         self,
         file_name: str,
@@ -27,7 +28,6 @@ class Upscale:
         scale: float = 1.5,
         suffix: str = "scaled",
         tempdir: Optional[str] = None,
-        method: str = "pdfrw",
     ):
         self.file_name = file_name
         self.margin_x = margin_x
@@ -53,17 +53,12 @@ class Upscale:
         self.target_w = dims["w"] * self.scale
         self.target_h = dims["h"] * self.scale
 
-        self.method = method
-
     def __str__(self) -> str:
         return self.file
 
     def upscale(self) -> str:
         # Execute either pdfrw or PyPDF3 method
-        if self.method.startswith("pypdf"):
-            return self.pypdf()
-        else:
-            return self.pdfrw()
+        return self.execute()
 
     @property
     def file(self) -> str:
@@ -118,4 +113,9 @@ def upscale(
     tempdir: Optional[str] = None,
     method: str = "pdfrw",
 ):
-    return Upscale(file_name, margin_x, margin_y, scale, suffix, tempdir, method).upscale()
+    upscaler = Upscale(file_name, margin_x, margin_y, scale, suffix, tempdir)
+    if method == 'pdfrw':
+        upscaler.use_pdfrw()
+    else:
+        upscaler.use_pypdf()
+    return upscaler.upscale()

--- a/pdfconduit/utils/driver.py
+++ b/pdfconduit/utils/driver.py
@@ -8,8 +8,8 @@ except ImportError:
 
 
 class Driver(Enum):
-    pdfrw: str = 'pdfrw'
-    pypdf: str = 'pypdf'
+    pdfrw: str = "pdfrw"
+    pypdf: str = "pypdf"
 
 
 class PdfDriver(ABC):

--- a/pdfconduit/utils/driver.py
+++ b/pdfconduit/utils/driver.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 
 try:
-    from typing import Self
+    from typing import Self, Union
 except ImportError:
     from typing_extensions import Self
 
@@ -16,11 +16,13 @@ class PdfDriver(ABC):
     _driver: Driver = Driver.pdfrw
 
     def use_pdfrw(self) -> Self:
-        self._driver = Driver.pdfrw
-        return self
+        return self.use(Driver.pdfrw)
 
     def use_pypdf(self) -> Self:
-        self._driver = Driver.pypdf
+        return self.use(Driver.pypdf)
+
+    def use(self, driver: Driver) -> Self:
+        self._driver = driver
         return self
 
     def is_driver_pdfrw(self) -> bool:

--- a/pdfconduit/utils/driver.py
+++ b/pdfconduit/utils/driver.py
@@ -38,3 +38,6 @@ class PdfDriver(ABC):
     @abstractmethod
     def pypdf(self) -> str:
         raise NotImplementedError
+
+    def execute(self) -> str:
+        return self.pdfrw() if self.is_driver_pdfrw() else self.pypdf()

--- a/pdfconduit/utils/driver.py
+++ b/pdfconduit/utils/driver.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+
+class Driver(Enum):
+    pdfrw: str = 'pdfrw'
+    pypdf: str = 'pypdf'
+
+
+class PdfDriver(ABC):
+    _driver: Driver = Driver.pdfrw
+
+    def use_pdfrw(self) -> Self:
+        self._driver = Driver.pdfrw
+        return self
+
+    def use_pypdf(self) -> Self:
+        self._driver = Driver.pypdf
+        return self
+
+    def is_driver_pdfrw(self) -> bool:
+        return self._driver == Driver.pdfrw
+
+    def is_driver_pypdf(self) -> bool:
+        return self._driver == Driver.pypdf
+
+    @abstractmethod
+    def pdfrw(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def pypdf(self) -> str:
+        raise NotImplementedError

--- a/samples/samples.py
+++ b/samples/samples.py
@@ -33,6 +33,7 @@ class Samples:
             watermarks.append(wm)
         watermarks.insert(0, self._title(wm, 'Watermark Images'))
         m = Merge(watermarks, 'Watermarks samples', self.dst)
+        m.merge()
         return m.file
 
     def opacity(self):
@@ -49,6 +50,7 @@ class Samples:
             samples.append(labeled_pdf)
             samples.insert(0, self._title(labeled_pdf, 'Opacity Comparisons'))
         m = Merge(samples, 'Opacity comparison samples', self.dst)
+        m.merge()
         return m.file
 
     def placement(self):
@@ -64,6 +66,7 @@ class Samples:
 
         to_merge = [self._title(under, 'Watermark Placement'), over_with_label, under_with_label]
         m = Merge(to_merge, 'Watermark Placement samples', self.dst)
+        m.merge()
         return m.file
 
     def layering(self):
@@ -86,6 +89,7 @@ class Samples:
             watermark_layer
         ]
         m = Merge(to_merge, 'Layering samples', self.dst)
+        m.merge()
         return m.file
 
     def flat(self):
@@ -106,6 +110,7 @@ class Samples:
         # Merge files
         to_merge = [self._title(flattened_labeled, 'Flat vs. Layered pages'), flattened_labeled, wtrmrked_labeled]
         m = Merge(to_merge, 'Flat vs. Layered', self.dst)
+        m.merge()
         return m.file
 
 

--- a/tests/test_transform_merge.py
+++ b/tests/test_transform_merge.py
@@ -31,6 +31,7 @@ class TestMerge(unittest.TestCase):
             output_dir=self.temp.name,
             method="pdfrw",
         )
+        merged.merge()
 
         # Assert merged file exists
         self.assertTrue(os.path.exists(merged.file))
@@ -57,6 +58,7 @@ class TestMerge(unittest.TestCase):
             output_dir=self.temp.name,
             method="pypdf",
         )
+        merged.merge()
 
         # Assert merged file exists
         self.assertTrue(os.path.exists(merged.file))

--- a/tests/test_transform_merge.py
+++ b/tests/test_transform_merge.py
@@ -29,8 +29,7 @@ class TestMerge(unittest.TestCase):
             self.pdfs,
             output_name="merged_pdfrw",
             output_dir=self.temp.name,
-            method="pdfrw",
-        )
+        ).use_pdfrw()
         merged.merge()
 
         # Assert merged file exists
@@ -56,8 +55,7 @@ class TestMerge(unittest.TestCase):
             self.pdfs,
             output_name="merged_pypdf",
             output_dir=self.temp.name,
-            method="pypdf",
-        )
+        ).use_pypdf()
         merged.merge()
 
         # Assert merged file exists

--- a/tests/test_transform_rotate.py
+++ b/tests/test_transform_rotate.py
@@ -23,12 +23,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pdfrw_90(self):
         """Rotate a PDF file by 90 degrees using the `pdfrw` library."""
         rotation = 90
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_90_pdfrw",
-            tempdir=self.temp.name
-        ).use_pdfrw().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_90_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -39,12 +43,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pdfrw_180(self):
         """Rotate a PDF file by 180 degrees using the `pdfrw` library."""
         rotation = 180
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_180_pdfrw",
-            tempdir=self.temp.name
-        ).use_pdfrw().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_180_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -55,12 +63,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pdfrw_270(self):
         """Rotate a PDF file by 270 degrees using the `pdfrw` library."""
         rotation = 270
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_270_pdfrw",
-            tempdir=self.temp.name
-        ).use_pdfrw().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_270_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -71,12 +83,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pypdf_90(self):
         """Rotate a PDF file by 90 degrees using the `pypdf` library."""
         rotation = 90
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_90_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_90_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -87,12 +103,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pypdf_180(self):
         """Rotate a PDF file by 180 degrees using the `pypdf` library."""
         rotation = 180
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_180_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_180_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -103,12 +123,16 @@ class TestRotate(unittest.TestCase):
     def test_rotate_pypdf_270(self):
         """Rotate a PDF file by 270 degrees using the `pypdf` library."""
         rotation = 270
-        rotated = Rotate(
-            self.pdf_path,
-            rotation,
-            suffix="rotated_270_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().rotate()
+        rotated = (
+            Rotate(
+                self.pdf_path,
+                rotation,
+                suffix="rotated_270_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .rotate()
+        )
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)

--- a/tests/test_transform_rotate.py
+++ b/tests/test_transform_rotate.py
@@ -29,7 +29,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_90_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -46,7 +46,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_180_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -63,7 +63,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_270_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -80,7 +80,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_90_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -97,7 +97,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_180_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -114,7 +114,7 @@ class TestRotate(unittest.TestCase):
             suffix="rotated_270_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)

--- a/tests/test_transform_rotate.py
+++ b/tests/test_transform_rotate.py
@@ -27,9 +27,8 @@ class TestRotate(unittest.TestCase):
             self.pdf_path,
             rotation,
             suffix="rotated_90_pdfrw",
-            tempdir=self.temp.name,
-            method="pdfrw",
-        ).rotate()
+            tempdir=self.temp.name
+        ).use_pdfrw().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -44,9 +43,8 @@ class TestRotate(unittest.TestCase):
             self.pdf_path,
             rotation,
             suffix="rotated_180_pdfrw",
-            tempdir=self.temp.name,
-            method="pdfrw",
-        ).rotate()
+            tempdir=self.temp.name
+        ).use_pdfrw().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -61,9 +59,8 @@ class TestRotate(unittest.TestCase):
             self.pdf_path,
             rotation,
             suffix="rotated_270_pdfrw",
-            tempdir=self.temp.name,
-            method="pdfrw",
-        ).rotate()
+            tempdir=self.temp.name
+        ).use_pdfrw().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -79,8 +76,7 @@ class TestRotate(unittest.TestCase):
             rotation,
             suffix="rotated_90_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).rotate()
+        ).use_pypdf().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -96,8 +92,7 @@ class TestRotate(unittest.TestCase):
             rotation,
             suffix="rotated_180_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).rotate()
+        ).use_pypdf().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)
@@ -113,8 +108,7 @@ class TestRotate(unittest.TestCase):
             rotation,
             suffix="rotated_270_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).rotate()
+        ).use_pypdf().rotate()
 
         self.assertPdfExists(rotated)
         self.assertPdfRotation(rotated, rotation)

--- a/tests/test_transform_upscale.py
+++ b/tests/test_transform_upscale.py
@@ -26,8 +26,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_2.0_pdfrw",
             tempdir=self.temp.name,
-            method="pdfrw",
-        ).upscale()
+        ).use_pdfrw().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -42,8 +41,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_1.5_pdfrw",
             tempdir=self.temp.name,
-            method="pdfrw",
-        ).upscale()
+        ).use_pdfrw().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -58,8 +56,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_3.0_pdfrw",
             tempdir=self.temp.name,
-            method="pdfrw",
-        ).upscale()
+        ).use_pdfrw().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -74,8 +71,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="downscaled_2.0_pdfrw",
             tempdir=self.temp.name,
-            method="pdfrw",
-        ).upscale()
+        ).use_pdfrw().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -90,8 +86,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_2.0_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).upscale()
+        ).use_pypdf().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -106,8 +101,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_1.5_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).upscale()
+        ).use_pypdf().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -122,8 +116,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="upscaled_3.0_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).upscale()
+        ).use_pypdf().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -138,8 +131,7 @@ class TestUpscale(unittest.TestCase):
             scale=s,
             suffix="downscaled_2.0_pypdf",
             tempdir=self.temp.name,
-            method="pypdf",
-        ).upscale()
+        ).use_pypdf().upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)

--- a/tests/test_transform_upscale.py
+++ b/tests/test_transform_upscale.py
@@ -27,7 +27,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_2.0_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -43,7 +43,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_1.5_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -59,7 +59,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_3.0_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -75,7 +75,7 @@ class TestUpscale(unittest.TestCase):
             suffix="downscaled_2.0_pdfrw",
             tempdir=self.temp.name,
             method="pdfrw",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -91,7 +91,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_2.0_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -107,7 +107,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_1.5_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -123,7 +123,7 @@ class TestUpscale(unittest.TestCase):
             suffix="upscaled_3.0_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -139,7 +139,7 @@ class TestUpscale(unittest.TestCase):
             suffix="downscaled_2.0_pypdf",
             tempdir=self.temp.name,
             method="pypdf",
-        ).file
+        ).upscale()
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)

--- a/tests/test_transform_upscale.py
+++ b/tests/test_transform_upscale.py
@@ -21,12 +21,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pdfrw_20x(self):
         s = 2.0
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_2.0_pdfrw",
-            tempdir=self.temp.name,
-        ).use_pdfrw().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_2.0_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -36,12 +40,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pdfrw_15x(self):
         s = 1.5
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_1.5_pdfrw",
-            tempdir=self.temp.name,
-        ).use_pdfrw().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_1.5_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -51,12 +59,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pdfrw_30x(self):
         s = 3.0
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_3.0_pdfrw",
-            tempdir=self.temp.name,
-        ).use_pdfrw().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_3.0_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -66,12 +78,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_downscale_pdfrw_20x(self):
         s = 1 / 2
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="downscaled_2.0_pdfrw",
-            tempdir=self.temp.name,
-        ).use_pdfrw().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="downscaled_2.0_pdfrw",
+                tempdir=self.temp.name,
+            )
+            .use_pdfrw()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -81,12 +97,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pypdf_20x(self):
         s = 2.0
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_2.0_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_2.0_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -96,12 +116,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pypdf_15x(self):
         s = 1.5
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_1.5_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_1.5_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -111,12 +135,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_upscale_pypdf_30x(self):
         s = 3.0
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="upscaled_3.0_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="upscaled_3.0_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)
@@ -126,12 +154,16 @@ class TestUpscale(unittest.TestCase):
     @Timer.decorator
     def test_downscale_pypdf_20x(self):
         s = 1 / 2
-        upscaled = Upscale(
-            pdf_path,
-            scale=s,
-            suffix="downscaled_2.0_pypdf",
-            tempdir=self.temp.name,
-        ).use_pypdf().upscale()
+        upscaled = (
+            Upscale(
+                pdf_path,
+                scale=s,
+                suffix="downscaled_2.0_pypdf",
+                tempdir=self.temp.name,
+            )
+            .use_pypdf()
+            .upscale()
+        )
 
         self.assertPdfExists(upscaled)
         self.assertPdfUpscaled(s, upscaled)


### PR DESCRIPTION
- make `PdfDriver` abstract class with methods for selecting the driver
- add implementations of `PdfDriver` in add.py, merge.py, rotate.py & upscale.py
- cut all 'method' params from class `__init__()` methods so that the driver selection can be done after class instantiation 