### PR TITLE
Common types & import optimization

### DIFF
--- a/pdfconduit/internals/base.py
+++ b/pdfconduit/internals/base.py
@@ -1,15 +1,15 @@
 import os
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-from warnings import warn
 from abc import ABC
 from datetime import datetime
 from io import BytesIO
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+from warnings import warn
 
 from pypdf import PdfWriter, PdfReader
 
 from pdfconduit.internals.exceptions import OutputException
 from pdfconduit.utils import pypdf_reader, add_suffix
-from pdfconduit.utils.typing import Optional, Any, Dict, Self, Union
+from pdfconduit.utils.typing import Optional, Any, Dict, Self, PdfObject
 
 
 class BaseConduit(ABC):
@@ -29,7 +29,7 @@ class BaseConduit(ABC):
     _tempfile: Optional[NamedTemporaryFile] = None
 
     def __init__(
-        self, pdf: Union[str, BytesIO], decrypt_pw: Optional[str] = None
+        self, pdf: PdfObject, decrypt_pw: Optional[str] = None
     ) -> None:
         self._decrypt_pw = decrypt_pw
 
@@ -109,7 +109,7 @@ class BaseConduit(ABC):
         return self
 
     @property
-    def pdf_object(self) -> Union[str, BytesIO]:
+    def pdf_object(self) -> PdfObject:
         return self._stream if self._stream is not None else self._path
 
     def write_to_stream(self):

--- a/pdfconduit/internals/base.py
+++ b/pdfconduit/internals/base.py
@@ -108,6 +108,10 @@ class BaseConduit(ABC):
             self._tempdir.cleanup()
         return self
 
+    @property
+    def pdf_object(self) -> Union[str, BytesIO]:
+        return self._stream if self._stream is not None else self._path
+
     def write_to_stream(self):
         # todo: implement
         pass

--- a/pdfconduit/internals/base.py
+++ b/pdfconduit/internals/base.py
@@ -28,9 +28,7 @@ class BaseConduit(ABC):
     _tempdir: Optional[TemporaryDirectory] = None
     _tempfile: Optional[NamedTemporaryFile] = None
 
-    def __init__(
-        self, pdf: PdfObject, decrypt_pw: Optional[str] = None
-    ) -> None:
+    def __init__(self, pdf: PdfObject, decrypt_pw: Optional[str] = None) -> None:
         self._decrypt_pw = decrypt_pw
 
         if isinstance(pdf, BytesIO):

--- a/pdfconduit/pdfconduit.py
+++ b/pdfconduit/pdfconduit.py
@@ -36,7 +36,7 @@ class Pdfconduit(BaseConduit):
     def merge_fast(self, pdfs: list) -> Self:
         self._set_default_output("merged")
         # todo: extract method for stream or path
-        pdf_objects = [self._stream if self._stream is not None else self._path] + pdfs
+        pdf_objects = [self.pdf_object] + pdfs
         self._path = Merge2(pdf_objects, output=self.output).use_pdfrw().merge()
         return self._open_and_read()
 
@@ -53,7 +53,7 @@ class Pdfconduit(BaseConduit):
         self._set_default_output("rotated")
         self._path = (
             Rotate(
-                self._stream if self._stream is not None else self._path,
+                self.pdf_object,
                 degrees,
                 output=self.output,
             )
@@ -80,7 +80,7 @@ class Pdfconduit(BaseConduit):
             x, y = margins
             self._path = (
                 Scale(
-                    self._stream if self._stream is not None else self._path,
+                    self.pdf_object,
                     output=self.output,
                     scale=scale,
                     margin_x=x,

--- a/pdfconduit/pdfconduit.py
+++ b/pdfconduit/pdfconduit.py
@@ -1,6 +1,4 @@
-from tempfile import TemporaryFile, NamedTemporaryFile
-
-from pypdf import PdfWriter
+from tempfile import NamedTemporaryFile
 
 from pypdf import PdfWriter
 
@@ -8,7 +6,7 @@ from pdfconduit.convert import Flatten
 from pdfconduit.internals import BaseConduit
 from pdfconduit.settings import Compression, ImageQualityRange, Encryption
 from pdfconduit.transform import Merge2, Scale
-from pdfconduit.transform import Rotate, Upscale
+from pdfconduit.transform import Rotate
 from pdfconduit.utils import Info
 from pdfconduit.utils.typing import Optional, Tuple, Self, Annotated
 

--- a/pdfconduit/transform/merge2.py
+++ b/pdfconduit/transform/merge2.py
@@ -1,6 +1,5 @@
 # Merge PDF documents
 from io import BytesIO
-from typing import Union, Iterable
 
 from pdfrw import (
     PdfReader as PdfrwReader,
@@ -10,10 +9,11 @@ from pdfrw import (
 from pypdf import PdfWriter as PyPdfWriter
 
 from pdfconduit.utils.driver import PdfDriver
+from pdfconduit.utils.typing import PdfObjects
 
 
 class Merge2(PdfDriver):
-    def __init__(self, pdfs: Iterable[Union[str, BytesIO]], output: str):
+    def __init__(self, pdfs: PdfObjects, output: str):
         self._pdfs = pdfs
         self._output = output
 

--- a/pdfconduit/transform/rotate.py
+++ b/pdfconduit/transform/rotate.py
@@ -2,7 +2,7 @@
 import os
 from io import BytesIO
 from tempfile import NamedTemporaryFile
-from typing import Optional, Union
+from typing import Optional
 
 from pdfrw import (
     PdfReader as PdfrwReader,
@@ -12,13 +12,14 @@ from pypdf import PdfReader as PypdfReader, PdfWriter as PypdfWriter
 
 from pdfconduit.utils.driver import PdfDriver
 from pdfconduit.utils.path import add_suffix
+from pdfconduit.utils.typing import PdfObject
 
 
 class Rotate(PdfDriver):
 
     def __init__(
         self,
-        pdf: Union[str, BytesIO],
+        pdf: PdfObject,
         rotation: int,
         suffix: str = "rotated",
         tempdir: Optional[str] = None,

--- a/pdfconduit/transform/scale.py
+++ b/pdfconduit/transform/scale.py
@@ -1,6 +1,5 @@
 # Upscale a PDF file
 from io import BytesIO
-from typing import Union
 
 from pdfrw import (
     PdfReader as pdfrwReader,
@@ -15,12 +14,13 @@ from pypdf import (
 
 from pdfconduit.utils.driver import PdfDriver
 from pdfconduit.utils.info import Info
+from pdfconduit.utils.typing import PdfObject
 
 
 class Scale(PdfDriver):
     def __init__(
         self,
-        pdf: Union[str, BytesIO],
+        pdf: PdfObject,
         output: str,
         scale: float = 1.5,
         margin_x: int = 0,

--- a/pdfconduit/utils/typing/__init__.py
+++ b/pdfconduit/utils/typing/__init__.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from typing import Optional, Any, Tuple, Dict, Union, List, Iterable
 
 try:
@@ -5,5 +6,8 @@ try:
 except ImportError:
     from typing_extensions import Self, Annotated
 
+PdfObject = Union[str, BytesIO]
+PdfObjects = Iterable[PdfObject]
 
-__all__ = [Optional, Any, Tuple, Dict, Self, Annotated, Union, List, Iterable]
+
+__all__ = [Optional, Any, Tuple, Dict, Self, Annotated, Union, List, Iterable, PdfObject, PdfObjects]

--- a/pdfconduit/utils/typing/__init__.py
+++ b/pdfconduit/utils/typing/__init__.py
@@ -10,4 +10,16 @@ PdfObject = Union[str, BytesIO]
 PdfObjects = Iterable[PdfObject]
 
 
-__all__ = [Optional, Any, Tuple, Dict, Self, Annotated, Union, List, Iterable, PdfObject, PdfObjects]
+__all__ = [
+    Optional,
+    Any,
+    Tuple,
+    Dict,
+    Self,
+    Annotated,
+    Union,
+    List,
+    Iterable,
+    PdfObject,
+    PdfObjects,
+]

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Tuple
 
 from parameterized import parameterized

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,8 +1,6 @@
-import os.path
-
 from parameterized import parameterized
 
-from pdfconduit import Pdfconduit, Info
+from pdfconduit import Pdfconduit
 from pdfconduit.utils.typing import List, Iterable
 from tests import PdfconduitTestCase, get_clean_pdf_name
 from tests import test_data_path

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -1,4 +1,3 @@
-import os
 from typing import Tuple, List
 
 from parameterized import parameterized

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -3,7 +3,7 @@ from typing import List
 
 from parameterized import parameterized
 
-from pdfconduit import Info, Pdfconduit
+from pdfconduit import Pdfconduit
 from tests import PdfconduitTestCase
 
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -2,7 +2,6 @@ from typing import List
 
 from parameterized import parameterized
 
-from pdfconduit import Info
 from tests import PdfconduitTestCase
 
 

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -1,7 +1,7 @@
 from parameterized import parameterized
 
 from pdfconduit import Pdfconduit, Info
-from pdfconduit.settings import Encryption, Compression
+from pdfconduit.settings import Encryption
 from pdfconduit.utils.typing import List, Iterable
 from tests import *
 from tests.test_encrypt import EncryptionTestCase


### PR DESCRIPTION
- add `PdfObject` & `PdfObjects` type classes to pdfconduit.utils.typing module
  - adds a common type that can be used throughout the codebase 
- optimize imports