### PR TITLE
Instantiate `Pdfconduit` without a `PdfWriter` instance

### DIFF
--- a/pdfconduit/pdfconduit.py
+++ b/pdfconduit/pdfconduit.py
@@ -1,5 +1,3 @@
-from tempfile import NamedTemporaryFile
-
 from pypdf import PdfWriter
 
 from pdfconduit.convert import Flatten
@@ -139,7 +137,13 @@ class Pdfconduit(BaseConduit):
 
     @property
     def info(self) -> Info:
-        return Info(self._writer if not self._closed else self.output)
+        if self._closed:
+            pdf = self.output
+        elif self._writer:
+            pdf = self._writer
+        else:
+            pdf = self._reader
+        return Info(pdf)
 
     def watermark(self):
         # todo: add method

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -218,8 +218,8 @@ class TestInfo(PdfconduitTestCase):
         self.assertIsInstance(info, dict)
 
     @staticmethod
-    def _get_info(filepath: str, password: Optional[str] = None):
-        return Info(filepath, password=password)
+    def _get_info(filepath: str, password: Optional[str] = None) -> Info:
+        return Pdfconduit(filepath, password, with_writer=False).info
 
 
 def get_expected_output(filepath: str, suffix: str = "modified", sep: str = "_") -> str:


### PR DESCRIPTION
- add ability to instantiate `PdfConduit` using 'with_writer = false' in order to create an instance that only has a `PdfReader` & not a `PdfWriter`
-  useful when only PDF info needs to be retrieved and no actions and executed