### PR TITLE
Remove 'security' from `Info.all()` method return

### DIFF
--- a/pdfconduit/utils/info.py
+++ b/pdfconduit/utils/info.py
@@ -97,7 +97,6 @@ class Info:
             "encrypted": self.encrypted,
             "pages": self.pages,
             "metadata": self.metadata,
-            "security": self.security,
             "size": self.size,
             "rotate": self.rotate,
             "permissions": self.permissions,

--- a/pdfconduit/utils/typing/info/__init__.py
+++ b/pdfconduit/utils/typing/info/__init__.py
@@ -27,7 +27,7 @@ class InfoAllDict(TypedDict):
     encrypted: bool
     pages: int
     metadata: Metadata
-    security: SecurityDict
+    security: Optional[SecurityDict]
     size: SizeTuple
     rotate: int
     permissions: Optional[Permissions]

--- a/pdfconduit/utils/typing/info/__init__.py
+++ b/pdfconduit/utils/typing/info/__init__.py
@@ -27,7 +27,6 @@ class InfoAllDict(TypedDict):
     encrypted: bool
     pages: int
     metadata: Metadata
-    security: Optional[SecurityDict]
     size: SizeTuple
     rotate: int
     permissions: Optional[Permissions]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ from parameterized import parameterized
 
 from pdfconduit import Info, Pdfconduit
 from pdfconduit.utils import add_suffix
-from pdfconduit.utils.typing.info import InfoAllDict
 from tests import PdfconduitTestCase, get_clean_pdf_name
 from tests import test_data_path
 


### PR DESCRIPTION
- cut 'security' key from `Info.all()` methods return dict because it contains unserializable values