### PR TITLE
PDF to Image (pdf2img.py) refactor

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   optimize-imports:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +32,7 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Install code import optimizer dependencies
-        run: python -m pip install -r requirements/imports.txt
+        run: python -m pip install -r requirements-imports.txt
 
       - name: Run Import Optimizers
         run: |
@@ -44,7 +46,7 @@ jobs:
           file_pattern: '*.py'
 
       - name: Install code style fixer dependencies
-        run: python -m pip install -r requirements/style.txt
+        run: python -m pip install -r requirements-style.txt
 
       - name: Run Code Style Fixer
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Code Style Fixer
         run: |
-          black app
+          black pdfconduit
           black tests
 
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/pdfconduit/convert/flatten.py
+++ b/pdfconduit/convert/flatten.py
@@ -46,7 +46,7 @@ class Flatten:
         return str(self.pdf)
 
     def get_imgs(self) -> List[str]:
-        self.imgs = PDF2IMG(self.file_name, tempdir=self.tempdir).save()
+        self.imgs = PDF2IMG(self.file_name, output=self.tempdir).convert()
         return self.imgs
 
     def save(self, remove_temps: bool = True) -> str:

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -32,6 +32,7 @@ class PDF2IMG:
         if isinstance(self._pdf, BytesIO):
             self._tempfile = NamedTemporaryFile(suffix=self._ext, dir=self._directory, delete=False)
             self._filename = self._tempfile.name
+            self._directory = os.path.dirname(self._filename)
             self._doc = fitz.open(stream=self._pdf)
         else:
             self._filename = os.path.basename(self._pdf)

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -9,10 +9,10 @@ import fitz
 from PIL import Image
 
 try:
-    from pymupdf import Document as PyMupdfDocument, DisplayList
+    from pymupdf import DisplayList
+    from pymupdf import Document as PyMupdfDocument
 except ImportError:
     from fitz import Document as PyMupdfDocument, DisplayList
-
 
 from pdfconduit.utils.path import add_suffix
 from pdfconduit.utils.typing import PdfObject

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -23,14 +23,22 @@ class PDF2IMG:
     _tempfile: Optional[NamedTemporaryFile] = None
     _doc: PyMupdfDocument
 
-    def __init__(self, pdf: PdfObject, output: Optional[str] = None, ext: ImageExtension = ImageExtension.PNG, alpha: bool = False):
+    def __init__(
+        self,
+        pdf: PdfObject,
+        output: Optional[str] = None,
+        ext: ImageExtension = ImageExtension.PNG,
+        alpha: bool = False,
+    ):
         self._pdf = pdf
         self._directory = output
         self._ext = ext.value
         self._alpha = alpha
 
         if isinstance(self._pdf, BytesIO):
-            self._tempfile = NamedTemporaryFile(suffix=self._ext, dir=self._directory, delete=False)
+            self._tempfile = NamedTemporaryFile(
+                suffix=self._ext, dir=self._directory, delete=False
+            )
             self._filename = self._tempfile.name
             self._directory = os.path.dirname(self._filename)
             self._doc = fitz.open(stream=self._pdf)
@@ -42,7 +50,10 @@ class PDF2IMG:
     def convert(self):
         saved = []
         for index, image in enumerate(self._get_pdf_data()):
-            output = os.path.join(self._directory, add_suffix(self._filename, str(index + 1), ext=self._ext))
+            output = os.path.join(
+                self._directory,
+                add_suffix(self._filename, str(index + 1), ext=self._ext),
+            )
             with Image.open(BytesIO(image)) as pillow:
                 pillow.save(output)
             saved.append(output)

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -7,7 +7,12 @@ from typing import List, Optional
 
 import fitz
 from PIL import Image
-from pymupdf import Document as PyMupdfDocument
+
+try:
+    from pymupdf import Document as PyMupdfDocument
+except ImportError:
+    from fitz import Document as PyMupdfDocument
+
 
 from pdfconduit.utils.path import add_suffix
 from pdfconduit.utils.typing import PdfObject

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -1,56 +1,77 @@
 # Convert each page of PDF to images
 import os
+from enum import Enum
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
 import fitz
 from PIL import Image
+from pymupdf import Document as PyMupdfDocument
 
 from pdfconduit.utils.path import add_suffix
+from pdfconduit.utils.typing import PdfObject
+
+
+class ImageExtension(Enum):
+    PNG: str = "png"
+    JPG: str = "jpg"
 
 
 class PDF2IMG:
-    def __init__(
-        self,
-        file_name: str,
-        output: Optional[str] = None,
-        tempdir: Optional[str] = None,
-        ext: str = ".png",
-        alpha: bool = False,
-    ):
-        """Convert each page of a PDF file into a PNG image"""
-        self.file_name = file_name
-        self.output = output
-        self.tempdir = tempdir
-        self.ext = ext
-        self.alpha = alpha
+    _filename: str = None
+    _tempfile: Optional[NamedTemporaryFile] = None
+    _doc: PyMupdfDocument
 
-        self.doc = fitz.open(self.file_name)
-        self.output_dir = os.path.dirname(file_name) if tempdir is None else tempdir
+    def __init__(self, pdf: PdfObject, output: Optional[str] = None, ext: ImageExtension = ImageExtension.PNG, alpha: bool = False):
+        self._pdf = pdf
+        self._directory = output
+        self._ext = ext.value
+        self._alpha = alpha
 
-        # storage for page display lists
-        self.dlist_tab = [None] * len(self.doc)
-        self._page_data = None
+        if isinstance(self._pdf, BytesIO):
+            self._tempfile = NamedTemporaryFile(suffix=self._ext, dir=self._directory, delete=False)
+            self._filename = self._tempfile.name
+            self._doc = fitz.open(stream=self._pdf)
+        else:
+            self._filename = os.path.basename(self._pdf)
+            self._directory = os.path.dirname(self._pdf)
+            self._doc = fitz.open(filename=self._pdf)
 
-    @property
-    def pdf_data(self) -> List[bytes]:
-        if not self._page_data:
-            self._page_data = self._get_pdf_data()
-        return self._page_data
+    def convert(self):
+        saved = []
+        for index, image in enumerate(self._get_pdf_data()):
+            output = os.path.join(self._directory, add_suffix(self._filename, str(index + 1), ext=self._ext))
+            with Image.open(BytesIO(image)) as pillow:
+                pillow.save(output)
+            saved.append(output)
+        self._doc.close()
+        if self._tempfile:
+            self._tempfile.close()
+        return saved
 
     def _get_pdf_data(self) -> List[bytes]:
-        return [self._get_page_data(cur_page) for cur_page in range(len(self.doc))]
+        return FitzPdfToImage(self._doc, self._alpha).convert()
+
+
+class FitzPdfToImage:
+    def __init__(self, doc: PyMupdfDocument, alpha: bool = False):
+        self._doc = doc
+        self._dlist_tab = [None] * len(doc)
+        self._alpha = alpha
+
+    def convert(self) -> List[bytes]:
+        return [self._get_page_data(cur_page) for cur_page in range(len(self._doc))]
 
     def _get_page_data(self, pno, zoom=0) -> bytes:
         """
         Return a PNG image for a document page number. If zoom is other than 0, one of
         the 4 page quadrants are zoomed-in instead and the corresponding clip returned.
         """
-        dlist = self.dlist_tab[pno]  # get display list
+        dlist = self._dlist_tab[pno]  # get display list
         if not dlist:  # create if not yet there
-            self.dlist_tab[pno] = self.doc[pno].get_displaylist()
-            dlist = self.dlist_tab[pno]
+            self._dlist_tab[pno] = self._doc[pno].get_displaylist()
+            dlist = self._dlist_tab[pno]
         r = dlist.rect  # page rectangle
         mp = r.tl + (r.br - r.tl) * 0.5  # rect middle point
         mt = r.tl + (r.tr - r.tl) * 0.5  # middle of top edge
@@ -67,29 +88,7 @@ class PDF2IMG:
         elif zoom == 3:  # bot-left
             clip = fitz.Rect(ml, mb)
         if zoom == 0:  # total page
-            pix = dlist.get_pixmap(alpha=self.alpha)
+            pix = dlist.get_pixmap(alpha=self._alpha)
         else:
-            pix = dlist.get_pixmap(alpha=self.alpha, matrix=mat, clip=clip)
+            pix = dlist.get_pixmap(alpha=self._alpha, matrix=mat, clip=clip)
         return pix.tobytes()  # return the PNG image
-
-    def _get_output(self, index: int) -> str:
-        if self.output:
-            return self.output
-        elif not self.tempdir:
-            output_file = add_suffix(self.file_name, str(index + 1), ext=self.ext)
-            return os.path.join(self.output_dir, output_file)
-        else:
-            with NamedTemporaryFile(
-                suffix=self.ext, dir=self.tempdir, delete=True
-            ) as temp:
-                return temp.name
-
-    def save(self) -> List[str]:
-        saved = []
-        for i, img in enumerate(self.pdf_data):
-            output = self._get_output(i)
-            saved.append(output)
-            with Image.open(BytesIO(img)) as image:
-                image.save(output)
-        self.doc.close()
-        return saved

--- a/pdfconduit/convert/pdf2img.py
+++ b/pdfconduit/convert/pdf2img.py
@@ -9,9 +9,9 @@ import fitz
 from PIL import Image
 
 try:
-    from pymupdf import Document as PyMupdfDocument
+    from pymupdf import Document as PyMupdfDocument, DisplayList
 except ImportError:
-    from fitz import Document as PyMupdfDocument
+    from fitz import Document as PyMupdfDocument, DisplayList
 
 
 from pdfconduit.utils.path import add_suffix
@@ -85,7 +85,7 @@ class FitzPdfToImage:
         Return a PNG image for a document page number. If zoom is other than 0, one of
         the 4 page quadrants are zoomed-in instead and the corresponding clip returned.
         """
-        dlist = self._dlist_tab[pno]  # get display list
+        dlist: Optional[DisplayList] = self._dlist_tab[pno]  # get display list
         if not dlist:  # create if not yet there
             self._dlist_tab[pno] = self._doc[pno].get_displaylist()
             dlist = self._dlist_tab[pno]

--- a/tests/test_convert_pdf2img.py
+++ b/tests/test_convert_pdf2img.py
@@ -17,14 +17,16 @@ class TestPdf2Img(unittest.TestCase):
 
     def test_pdf2img(self):
         """Convert a PDF file to a png image."""
-        img = PDF2IMG(self.pdf_path).save()
+        images = PDF2IMG(self.pdf_path).convert()
 
         # Assert img file exists
-        self.assertTrue(os.path.exists(img[0]))
+        self.assertTrue(os.path.exists(images[0]))
 
         # Assert img file is correct file type
-        self.assertTrue(img[0].endswith(".png"))
-        self.img = img[0]
+        self.assertTrue(images[0].endswith(".png"))
+        self.img = images[0]
+
+    #todo: add from stream test
 
 
 if __name__ == "__main__":

--- a/tests/test_convert_pdf2img.py
+++ b/tests/test_convert_pdf2img.py
@@ -27,7 +27,6 @@ def convert_pdf2img_name_func(testcase_func, param_num, param):
     return "{}.{}".format(testcase_func.__name__, get_clean_pdf_name(param.args[0]))
 
 
-
 class TestPdf2Img(PdfconduitTestCase):
     @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
     def test_convert_pdf_to_images(self, pdf: str):
@@ -64,7 +63,9 @@ class TestPdf2Img(PdfconduitTestCase):
 
     @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
     def test_convert_pdf_to_images_jpg_from_stream(self, pdf: str):
-        images = PDF2IMG(self._get_pdf_byte_stream(pdf), ext=ImageExtension.JPG).convert()
+        images = PDF2IMG(
+            self._get_pdf_byte_stream(pdf), ext=ImageExtension.JPG
+        ).convert()
 
         for image in images:
             # Assert img file exists
@@ -72,6 +73,7 @@ class TestPdf2Img(PdfconduitTestCase):
 
             # Assert img file is correct file type
             self.assertTrue(image.endswith(".jpg"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_convert_pdf2img.py
+++ b/tests/test_convert_pdf2img.py
@@ -1,33 +1,77 @@
 import os
 import unittest
+from typing import List
+
+from parameterized import parameterized
 
 from pdfconduit.convert import PDF2IMG
+from pdfconduit.convert.pdf2img import ImageExtension
 from tests import *
 
 
-class TestPdf2Img(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.pdf_path = os.path.join(test_data_dir, "plan_p.pdf")
-        cls.img = None
+def convert_pdf2img_params() -> List[str]:
+    return list(
+        map(
+            lambda filename: test_data_path(filename),
+            [
+                "article.pdf",
+                "charts.pdf",
+                "document.pdf",
+                "plan_p.pdf",
+            ],
+        )
+    )
 
-    def tearDown(self):
-        if os.path.exists(self.img):
-            os.remove(self.img)
 
-    def test_pdf2img(self):
-        """Convert a PDF file to a png image."""
-        images = PDF2IMG(self.pdf_path).convert()
+def convert_pdf2img_name_func(testcase_func, param_num, param):
+    return "{}.{}".format(testcase_func.__name__, get_clean_pdf_name(param.args[0]))
 
-        # Assert img file exists
-        self.assertTrue(os.path.exists(images[0]))
 
-        # Assert img file is correct file type
-        self.assertTrue(images[0].endswith(".png"))
-        self.img = images[0]
 
-    #todo: add from stream test
+class TestPdf2Img(PdfconduitTestCase):
+    @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
+    def test_convert_pdf_to_images(self, pdf: str):
+        images = PDF2IMG(pdf).convert()
 
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(".png"))
+
+    @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
+    def test_convert_pdf_to_images_jpg(self, pdf: str):
+        images = PDF2IMG(pdf, ext=ImageExtension.JPG).convert()
+
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(".jpg"))
+
+    @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
+    def test_convert_pdf_to_images_from_stream(self, pdf: str):
+        images = PDF2IMG(self._get_pdf_byte_stream(pdf)).convert()
+
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(".png"))
+
+    @parameterized.expand(convert_pdf2img_params, name_func=convert_pdf2img_name_func)
+    def test_convert_pdf_to_images_jpg_from_stream(self, pdf: str):
+        images = PDF2IMG(self._get_pdf_byte_stream(pdf), ext=ImageExtension.JPG).convert()
+
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(".jpg"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- refactor pdf2img.py module so that PDF streams can be used as PDF inputs and simplified initialization params
- add tests for converting PDFs to Images from streams and to PNGs and JPGs