### PR TITLE
New `Pdfconduit.to_images()` method

### DIFF
--- a/pdfconduit/pdfconduit.py
+++ b/pdfconduit/pdfconduit.py
@@ -1,6 +1,7 @@
 from pypdf import PdfWriter
 
-from pdfconduit.convert import Flatten
+from pdfconduit.convert import Flatten, PDF2IMG
+from pdfconduit.convert.pdf2img import ImageExtension
 from pdfconduit.internals import BaseConduit
 from pdfconduit.settings import Compression, Encryption
 from pdfconduit.transform import Merge2, Rotate, Scale
@@ -110,6 +111,9 @@ class Pdfconduit(BaseConduit):
         ).save()
 
         return self._open_and_read()
+
+    def to_images(self, ext: ImageExtension = ImageExtension.PNG, alpha: bool = False, output: Optional[str] = None):
+        return PDF2IMG(self.pdf_object, ext=ext, alpha=alpha).convert()
 
     def minify(self) -> Self:
         # remove duplication (images or pages) from a PDF

--- a/pdfconduit/pdfconduit.py
+++ b/pdfconduit/pdfconduit.py
@@ -1,6 +1,6 @@
 from pypdf import PdfWriter
 
-from pdfconduit.convert import Flatten, PDF2IMG
+from pdfconduit.convert import PDF2IMG, Flatten
 from pdfconduit.convert.pdf2img import ImageExtension
 from pdfconduit.internals import BaseConduit
 from pdfconduit.settings import Compression, Encryption
@@ -112,7 +112,12 @@ class Pdfconduit(BaseConduit):
 
         return self._open_and_read()
 
-    def to_images(self, ext: ImageExtension = ImageExtension.PNG, alpha: bool = False, output: Optional[str] = None):
+    def to_images(
+        self,
+        ext: ImageExtension = ImageExtension.PNG,
+        alpha: bool = False,
+        output: Optional[str] = None,
+    ):
         return PDF2IMG(self.pdf_object, ext=ext, alpha=alpha).convert()
 
     def minify(self) -> Self:

--- a/tests/test_convert_pdf2img_new.py
+++ b/tests/test_convert_pdf2img_new.py
@@ -17,14 +17,8 @@ def params() -> List[Tuple[str, ImageExtension, bool]]:
         "document.pdf",
         "plan_p.pdf",
     ]
-    extensions = [
-        ImageExtension.PNG,
-        ImageExtension.JPG
-    ]
-    from_stream = [
-        True,
-        False
-    ]
+    extensions = [ImageExtension.PNG, ImageExtension.JPG]
+    from_stream = [True, False]
 
     return [
         (test_data_path(file), extension, use_stream)
@@ -36,17 +30,21 @@ def params() -> List[Tuple[str, ImageExtension, bool]]:
 
 def name_func(testcase_func, param_num, param):
     return "{}.{}.{}.{}".format(
-        testcase_func.__name__, # test func
-        param.args[1].value, # image extension
-        'from_stream' if param.args[2] is True else 'from_file', # stream vs. file
-        get_clean_pdf_name(param.args[0]) # filename
+        testcase_func.__name__,  # test func
+        param.args[1].value,  # image extension
+        "from_stream" if param.args[2] is True else "from_file",  # stream vs. file
+        get_clean_pdf_name(param.args[0]),  # filename
     )
 
 
 class TestPdf2Img(PdfconduitTestCase):
     @parameterized.expand(params, name_func=name_func)
-    def test_convert_pdf_to_images_pdf2img(self, pdf: str, ext: ImageExtension, from_stream: bool):
-        images = PDF2IMG(pdf if not from_stream else self._get_pdf_byte_stream(pdf), ext=ext).convert()
+    def test_convert_pdf_to_images_pdf2img(
+        self, pdf: str, ext: ImageExtension, from_stream: bool
+    ):
+        images = PDF2IMG(
+            pdf if not from_stream else self._get_pdf_byte_stream(pdf), ext=ext
+        ).convert()
 
         for image in images:
             # Assert img file exists
@@ -56,8 +54,12 @@ class TestPdf2Img(PdfconduitTestCase):
             self.assertTrue(image.endswith(ext.value))
 
     @parameterized.expand(params, name_func=name_func)
-    def test_convert_pdf_to_images_pdfconduit(self, pdf: str, ext: ImageExtension, from_stream: bool):
-        images = Pdfconduit(pdf if not from_stream else self._get_pdf_byte_stream(pdf)).to_images(ext=ext)
+    def test_convert_pdf_to_images_pdfconduit(
+        self, pdf: str, ext: ImageExtension, from_stream: bool
+    ):
+        images = Pdfconduit(
+            pdf if not from_stream else self._get_pdf_byte_stream(pdf)
+        ).to_images(ext=ext)
 
         for image in images:
             # Assert img file exists

--- a/tests/test_convert_pdf2img_new.py
+++ b/tests/test_convert_pdf2img_new.py
@@ -1,0 +1,71 @@
+import os
+import unittest
+from typing import List, Tuple
+
+from parameterized import parameterized
+
+from pdfconduit import Pdfconduit
+from pdfconduit.convert import PDF2IMG
+from pdfconduit.convert.pdf2img import ImageExtension
+from tests import *
+
+
+def params() -> List[Tuple[str, ImageExtension, bool]]:
+    files = [
+        "article.pdf",
+        "charts.pdf",
+        "document.pdf",
+        "plan_p.pdf",
+    ]
+    extensions = [
+        ImageExtension.PNG,
+        ImageExtension.JPG
+    ]
+    from_stream = [
+        True,
+        False
+    ]
+
+    return [
+        (test_data_path(file), extension, use_stream)
+        for use_stream in from_stream
+        for extension in extensions
+        for file in files
+    ]
+
+
+def name_func(testcase_func, param_num, param):
+    return "{}.{}.{}.{}".format(
+        testcase_func.__name__, # test func
+        param.args[1].value, # image extension
+        'from_stream' if param.args[2] is True else 'from_file', # stream vs. file
+        get_clean_pdf_name(param.args[0]) # filename
+    )
+
+
+class TestPdf2Img(PdfconduitTestCase):
+    @parameterized.expand(params, name_func=name_func)
+    def test_convert_pdf_to_images_pdf2img(self, pdf: str, ext: ImageExtension, from_stream: bool):
+        images = PDF2IMG(pdf if not from_stream else self._get_pdf_byte_stream(pdf), ext=ext).convert()
+
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(ext.value))
+
+    @parameterized.expand(params, name_func=name_func)
+    def test_convert_pdf_to_images_pdfconduit(self, pdf: str, ext: ImageExtension, from_stream: bool):
+        images = Pdfconduit(pdf if not from_stream else self._get_pdf_byte_stream(pdf)).to_images(ext=ext)
+
+        for image in images:
+            # Assert img file exists
+            self.assertTrue(os.path.exists(image))
+
+            # Assert img file is correct file type
+            self.assertTrue(image.endswith(ext.value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- add new `Pdfconduit.to_images()` method for converting PDFs to images without additional imports