### PR TITLE
Add `suffix` property to `BaseConduit` (accessible via `Pdfconduit`)

### DIFF
--- a/pdfconduit/_version.py
+++ b/pdfconduit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "4.5.1"
+__version__ = "4.5.2-beta1"

--- a/pdfconduit/internals/base.py
+++ b/pdfconduit/internals/base.py
@@ -159,7 +159,9 @@ class BaseConduit(ABC):
         self._output_dir = directory
         return self
 
-    def set_output_temp(self, tempdir: Optional[TemporaryDirectory] = None, suffix: str = "") -> Self:
+    def set_output_temp(
+        self, tempdir: Optional[TemporaryDirectory] = None, suffix: str = ""
+    ) -> Self:
         self._suffix = suffix.replace("_", "")
         self._tempdir = tempdir if tempdir else TemporaryDirectory(prefix="pdfconduit_")
         self._tempfile = NamedTemporaryFile(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -147,6 +147,12 @@ class PdfconduitTestCase(unittest.TestCase):
     def assertFileSizeDecreased(self, original: str, modified: str):
         self.assertLess(os.path.getsize(modified), os.path.getsize(original))
 
+    def assertSuffixIsCorrect(self, output: str, expected_suffix: str):
+        self.assertTrue('_' in output)
+        self.assertTrue(expected_suffix in output)
+        self.assertTrue('.pdf' in output)
+        self.assertTrue(output.endswith('_{}.pdf'.format(expected_suffix)))
+
     def _get_pdf_byte_stream(self, path: Optional[str] = None) -> BytesIO:
         with open(path if path else self.pdf_path, "rb") as fh:
             return BytesIO(fh.read())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -148,10 +148,10 @@ class PdfconduitTestCase(unittest.TestCase):
         self.assertLess(os.path.getsize(modified), os.path.getsize(original))
 
     def assertSuffixIsCorrect(self, output: str, expected_suffix: str):
-        self.assertTrue('_' in output)
+        self.assertTrue("_" in output)
         self.assertTrue(expected_suffix in output)
-        self.assertTrue('.pdf' in output)
-        self.assertTrue(output.endswith('_{}.pdf'.format(expected_suffix)))
+        self.assertTrue(".pdf" in output)
+        self.assertTrue(output.endswith("_{}.pdf".format(expected_suffix)))
 
     def _get_pdf_byte_stream(self, path: Optional[str] = None) -> BytesIO:
         with open(path if path else self.pdf_path, "rb") as fh:

--- a/tests/test_conduit_watermark.py
+++ b/tests/test_conduit_watermark.py
@@ -25,7 +25,7 @@ def watermark_params() -> List[Tuple[str, str, bool, bool]]:
     ]
 
 
-def encryption_name_func(testcase_func, param_num, param):
+def watermark_name_func(testcase_func, param_num, param):
     return "{}.{}.{}".format(testcase_func.__name__, param.args[0], param.args[1])
 
 
@@ -46,7 +46,7 @@ class TestWatermark(unittest.TestCase):
     def tearDown(self):
         self.temp.cleanup()
 
-    @parameterized.expand(watermark_params, name_func=encryption_name_func)
+    @parameterized.expand(watermark_params, name_func=watermark_name_func)
     def test_watermark(
         self, name: str, method: str, flatten: bool = False, underneath: bool = False
     ):

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -152,7 +152,7 @@ class TestEncryption(EncryptionTestCase):
             can_modify=encryption.allow_commenting,
         )
 
-        self.assertSuffixIsCorrect(self.conduit.output, 'encrypted')
+        self.assertSuffixIsCorrect(self.conduit.output, "encrypted")
 
     def test_password_byte_string(self):
         self.conduit.encrypt(

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -152,6 +152,8 @@ class TestEncryption(EncryptionTestCase):
             can_modify=encryption.allow_commenting,
         )
 
+        self.assertSuffixIsCorrect(self.conduit.output, 'encrypted')
+
     def test_password_byte_string(self):
         self.conduit.encrypt(
             Encryption(user_pw="baz", owner_pw="foo", algo=Algorithms.RC4_128)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -53,7 +53,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, conduit.info.pages)
-        self.assertSuffixIsCorrect(conduit.output, 'merged')
+        self.assertSuffixIsCorrect(conduit.output, "merged")
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_from_stream(
@@ -71,7 +71,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
-        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
+        self.assertSuffixIsCorrect(self.conduit.output, "merged")
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_from_stream_with_streams(
@@ -89,7 +89,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
-        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
+        self.assertSuffixIsCorrect(self.conduit.output, "merged")
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_fast(self, main_pdf: str, pdfs_to_merge: List[str]):
@@ -102,7 +102,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
-        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
+        self.assertSuffixIsCorrect(self.conduit.output, "merged")
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_fast_from_stream(
@@ -119,4 +119,4 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
-        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
+        self.assertSuffixIsCorrect(self.conduit.output, "merged")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -53,6 +53,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, conduit.info.pages)
+        self.assertSuffixIsCorrect(conduit.output, 'merged')
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_from_stream(
@@ -70,6 +71,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
+        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_from_stream_with_streams(
@@ -87,6 +89,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
+        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_fast(self, main_pdf: str, pdfs_to_merge: List[str]):
@@ -99,6 +102,7 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
+        self.assertSuffixIsCorrect(self.conduit.output, 'merged')
 
     @parameterized.expand(merge_params, name_func=merge_name_func)
     def test_can_merge_pdfs_fast_from_stream(
@@ -115,3 +119,4 @@ class TestMerge(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectNumPages(main_pdf, pdfs_to_merge, self.conduit.info.pages)
+        self.assertSuffixIsCorrect(self.conduit.output, 'merged')

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -50,6 +50,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
         self.assertPdfPagesEqual(pdf_path, self.conduit.output)
+        self.assertSuffixIsCorrect(self.conduit.output, 'minified')
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_remove_duplication(self, pdf_path: str):
@@ -59,6 +60,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
         self.assertPdfPagesEqual(pdf_path, self.conduit.output)
+        self.assertSuffixIsCorrect(self.conduit.output, 'minified')
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_remove_images(self, pdf_path: str):
@@ -67,6 +69,7 @@ class TestOptimizations(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertEqual(0, self.conduit.info.images_count)
+        self.assertSuffixIsCorrect(self.conduit.output, 'noimages')
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_reduce_image_quality(self, pdf_path: str):
@@ -78,6 +81,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertEqual(Info(pdf_path).images_count, self.conduit.info.images_count)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
+        self.assertSuffixIsCorrect(self.conduit.output, 'reduced')
 
     @parameterized.expand(compress_params, name_func=compress_name_func)
     def test_compress(self, pdf_path: str, compression: Compression):
@@ -88,3 +92,4 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertEqual(Info(pdf_path).images_count, self.conduit.info.images_count)
         # todo: fix compression increasing size, maybe newer pdfs?
         # self.assertFileSizeDecreased(pdf_path, self.conduit.output)
+        self.assertSuffixIsCorrect(self.conduit.output, 'compress_{}'.format(compression.value))

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -50,7 +50,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
         self.assertPdfPagesEqual(pdf_path, self.conduit.output)
-        self.assertSuffixIsCorrect(self.conduit.output, 'minified')
+        self.assertSuffixIsCorrect(self.conduit.output, "minified")
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_remove_duplication(self, pdf_path: str):
@@ -60,7 +60,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
         self.assertPdfPagesEqual(pdf_path, self.conduit.output)
-        self.assertSuffixIsCorrect(self.conduit.output, 'minified')
+        self.assertSuffixIsCorrect(self.conduit.output, "minified")
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_remove_images(self, pdf_path: str):
@@ -69,7 +69,7 @@ class TestOptimizations(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertEqual(0, self.conduit.info.images_count)
-        self.assertSuffixIsCorrect(self.conduit.output, 'noimages')
+        self.assertSuffixIsCorrect(self.conduit.output, "noimages")
 
     @parameterized.expand(optimization_params, name_func=optimizations_name_func)
     def test_reduce_image_quality(self, pdf_path: str):
@@ -81,7 +81,7 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertPdfExists(self.conduit.output)
         self.assertEqual(Info(pdf_path).images_count, self.conduit.info.images_count)
         self.assertFileSizeDecreased(pdf_path, self.conduit.output)
-        self.assertSuffixIsCorrect(self.conduit.output, 'reduced')
+        self.assertSuffixIsCorrect(self.conduit.output, "reduced")
 
     @parameterized.expand(compress_params, name_func=compress_name_func)
     def test_compress(self, pdf_path: str, compression: Compression):
@@ -92,4 +92,6 @@ class TestOptimizations(PdfconduitTestCase):
         self.assertEqual(Info(pdf_path).images_count, self.conduit.info.images_count)
         # todo: fix compression increasing size, maybe newer pdfs?
         # self.assertFileSizeDecreased(pdf_path, self.conduit.output)
-        self.assertSuffixIsCorrect(self.conduit.output, 'compress_{}'.format(compression.value))
+        self.assertSuffixIsCorrect(
+            self.conduit.output, "compress_{}".format(compression.value)
+        )

--- a/tests/test_pdfconduit.py
+++ b/tests/test_pdfconduit.py
@@ -24,16 +24,16 @@ class TestUsage(PdfconduitTestCase):
         self.assertTrue(os.path.exists(conduit.output))
 
     def test_can_read_unencrypted_pdf(self):
-        conduit = Pdfconduit(self.pdf_path)
+        self.conduit = Pdfconduit(self.pdf_path)
 
-        self.assertIsInstance(conduit._pdf_file, BufferedReader)
-        self.assertIsInstance(conduit._reader, PdfReader)
+        self.assertIsInstance(self.conduit._pdf_file, BufferedReader)
+        self.assertIsInstance(self.conduit._reader, PdfReader)
 
     def test_can_read_encrypted_pdf(self):
-        conduit = Pdfconduit(test_data_path("encrypted.pdf"), self.user_pw)
+        self.conduit = Pdfconduit(test_data_path("encrypted.pdf"), self.user_pw)
 
-        self.assertIsInstance(conduit._pdf_file, BufferedReader)
-        self.assertIsInstance(conduit._reader, PdfReader)
+        self.assertIsInstance(self.conduit._pdf_file, BufferedReader)
+        self.assertIsInstance(self.conduit._reader, PdfReader)
 
     def test_can_set_default_metadata(self):
         original = self.conduit.info.metadata
@@ -69,37 +69,37 @@ class TestUsage(PdfconduitTestCase):
         self.assertEqual(output, self.conduit.output)
 
     def test_can_read_from_stream(self):
-        conduit = Pdfconduit(self._get_pdf_byte_stream())
+        self.conduit = Pdfconduit(self._get_pdf_byte_stream())
 
-        self.assertIsNone(conduit._pdf_file)
-        self.assertIsInstance(conduit._reader, PdfReader)
-        self.assertIsInstance(conduit._writer, PdfWriter)
+        self.assertIsNone(self.conduit._pdf_file)
+        self.assertIsInstance(self.conduit._reader, PdfReader)
+        self.assertIsInstance(self.conduit._writer, PdfWriter)
 
     def test_can_read_from_stream_and_write_to_file(self):
         output = os.path.join(self.temp.name, "streamed.pdf")
-        conduit = Pdfconduit(self._get_pdf_byte_stream()).set_output(output)
+        self.conduit = Pdfconduit(self._get_pdf_byte_stream()).set_output(output)
 
-        self.assertIsNone(conduit._pdf_file)
-        self.assertIsInstance(conduit._reader, PdfReader)
-        self.assertIsInstance(conduit._writer, PdfWriter)
+        self.assertIsNone(self.conduit._pdf_file)
+        self.assertIsInstance(self.conduit._reader, PdfReader)
+        self.assertIsInstance(self.conduit._writer, PdfWriter)
 
-        conduit.write()
+        self.conduit.write()
 
         self.assertPdfExists(output)
 
     def test_can_write_stream_to_file_without_output(self):
-        conduit = Pdfconduit(self._get_pdf_byte_stream())
+        self.conduit = Pdfconduit(self._get_pdf_byte_stream())
 
-        self.assertIsNone(conduit._pdf_file)
-        self.assertIsInstance(conduit._reader, PdfReader)
-        self.assertIsInstance(conduit._writer, PdfWriter)
+        self.assertIsNone(self.conduit._pdf_file)
+        self.assertIsInstance(self.conduit._reader, PdfReader)
+        self.assertIsInstance(self.conduit._writer, PdfWriter)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            conduit.write()
+            self.conduit.write()
 
-            self.assertPdfExists(conduit.output)
+            self.assertPdfExists(self.conduit.output)
 
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -37,6 +37,7 @@ class TestRotate(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertPdfRotation(self.conduit, rotation)
+        self.assertSuffixIsCorrect(self.conduit.output, "rotated_{}".format(rotation))
 
     @parameterized.expand(rotate_exact_params, name_func=rotate_name_func)
     def test_can_rotate_exact(self, rotation: int):
@@ -46,6 +47,7 @@ class TestRotate(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertPdfRotation(self.conduit, rotation)
+        self.assertSuffixIsCorrect(self.conduit.output, "rotated_{}".format(rotation))
 
     @parameterized.expand(rotate_exact_params, name_func=rotate_name_func)
     def test_cannot_rotate(self, rotation: int):
@@ -68,3 +70,4 @@ class TestRotate(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertPdfRotation(self.conduit, rotation)
+        self.assertSuffixIsCorrect(self.conduit.output, "rotated_{}".format(rotation))

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -28,6 +28,7 @@ class TestScale(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertPdfScaled(scale, self.conduit.output)
+        self.assertSuffixIsCorrect(self.conduit.output, suffix)
 
     @parameterized.expand(scale_params, name_func=scale_name_func)
     def test_scale_from_stream(self, scale: float, accelerate: bool):

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -35,3 +35,4 @@ class TestSlice(PdfconduitTestCase):
 
         self.assertPdfExists(self.conduit.output)
         self.assertCorrectPagesSliced(fp, lp, self.conduit)
+        self.assertSuffixIsCorrect(self.conduit.output, "sliced_{}".format(slice_range))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -203,15 +203,15 @@ class TestInfo(PdfconduitTestCase):
 
     @parameterized.expand(unencrypted_pdf_params, name_func=info_name_func)
     def test_get_all_info_unencrypted_from_stream(self, filepath: str):
-        conduit = Pdfconduit(self._get_pdf_byte_stream(filepath))
-        info = conduit.info.all
+        self.conduit = Pdfconduit(self._get_pdf_byte_stream(filepath))
+        info = self.conduit.info.all
 
         self.assertIsInstance(info, dict)
 
     @parameterized.expand(encrypted_pdf_params, name_func=info_name_func)
     def test_get_all_info_encrypted_from_stream(self, filepath: str):
-        conduit = Pdfconduit(self._get_pdf_byte_stream(filepath), "baz")
-        info = conduit.info.all
+        self.conduit = Pdfconduit(self._get_pdf_byte_stream(filepath), "baz")
+        info = self.conduit.info.all
 
         self.assertIsInstance(info, dict)
 


### PR DESCRIPTION
- add a `suffix` property to `BaseConduit` so that the set suffix can be later accessed (instead of just the full output filename WITH the suffix)
- add test assertions to confirm correct suffixes are used